### PR TITLE
Change method name 'list' to 'getComments'

### DIFF
--- a/SpringBoot咨询发布系统实战项目源码/springboot-project-news-publish-system/src/main/java/com/site/springboot/core/controller/admin/CommentController.java
+++ b/SpringBoot咨询发布系统实战项目源码/springboot-project-news-publish-system/src/main/java/com/site/springboot/core/controller/admin/CommentController.java
@@ -33,7 +33,7 @@ public class CommentController {
 
     @GetMapping("/comments/list")
     @ResponseBody
-    public Result list(@RequestParam Map<String, Object> params) {
+    public Result getComments(@RequestParam Map<String, Object> params) {
         if (StringUtils.isEmpty(params.get("page")) || StringUtils.isEmpty(params.get("limit"))) {
             return ResultGenerator.genFailResult("参数异常！");
         }


### PR DESCRIPTION
This class is used to control the Comment.  This method named 'list' is to get a list of comments. Thus, the method name 'getComments' is more intuitive than 'list'.